### PR TITLE
Move KINECT_DRIVER from .bashrc to Docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN /bin/bash -c "cd /open_ptrack/scripts; \
     ./openptrack_install.sh; \
 "
 
+ENV KINECT_DRIVER openni
+
 CMD [ 'roslaunch' ]

--- a/open_ptrack/scripts/ros_configure.sh
+++ b/open_ptrack/scripts/ros_configure.sh
@@ -13,6 +13,5 @@ catkin_make --force-cmake
 mkdir -p ~/workspace/ros/rosbuild
 rosws init ~/workspace/ros/rosbuild ~/workspace/ros/catkin/devel
 echo "source ~/workspace/ros/rosbuild/setup.bash" >> ~/.bashrc
-echo "export KINECT_DRIVER=openni" >> ~/.bashrc
 echo "export LC_ALL=C" >> ~/.bashrc
 


### PR DESCRIPTION
When KINECT_DRIVER is in .bashrc you can't pass it in as an environment
variable through Docker because it will be overwritten each time when
the bash session starts.

See issue #2 